### PR TITLE
explicit error when organization_id is not numeric

### DIFF
--- a/awx/resource_project.go
+++ b/awx/resource_project.go
@@ -71,8 +71,9 @@ func resourceProjectObject() *schema.Resource {
 				Optional: true,
 			},
 			"organization_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Numeric ID of the project organization",
 			},
 			"scm_update_on_launch": &schema.Schema{
 				Type:     schema.TypeBool,
@@ -100,6 +101,7 @@ func resourceProjectObject() *schema.Resource {
 func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 	awx := m.(*awxgo.AWX)
 	awxService := awx.ProjectService
+
 	_, res, err := awxService.ListProjects(map[string]string{
 		"name":         d.Get("name").(string),
 		"organization": d.Get("organization_id").(string)},
@@ -122,7 +124,7 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 		"scm_clean":                d.Get("scm_clean").(bool),
 		"scm_delete_on_update":     d.Get("scm_delete_on_update").(bool),
 		"credential_id":            AtoipOr(d.Get("credential_id").(string), nil),
-		"organization":             AtoipOr(d.Get("organization_id").(string), nil),
+		"organization":             d.Get("organization_id").(string),
 		"scm_update_on_launch":     d.Get("scm_update_on_launch").(bool),
 		"scm_update_cache_timeout": d.Get("scm_update_cache_timeout").(int),
 	}, map[string]string{})


### PR DESCRIPTION
Hi,

This pull request document the use of `organization_id` in the `project` resource
and explicit an error that yielded a cryptic error message.

I was trying to use the name of the organization as it's ID, like so:

```hcl
provider "awx" {
  endpoint = "http://localhost"
  username = "admin"
  password = "password"
}

resource "awx_project" "test" {
  ...
  organization_id = "Default"
}
```


Which yielded this error when running `terraform apply` :

```
Error: Error applying plan:

1 error(s) occurred:

* awx_project.test: 1 error(s) occurred:

* awx_project.test: responsed with 400, resp: &{400 Bad Request 400 HTTP/1.1 1 1 map[X-Api-Total-Time:[0.051s] Allow:[GET, POST, HEAD, OPTIONS] Vary:[Accept, Accept-Language, Cookie] Date:[Sat, 15 Sep 2018 21:02:05 GMT] Content-Length:[45] Connection:[keep-alive] Content-Language:[en] X-Api-Node:[awx] Server:[nginx/1.12.2] Content-Type:[application/json] X-Api-Time:[0.048s]] 0xc00007c100 45 [] false false map[] 0xc000192100 <nil>}
```

This error happens on the `ListProjects` API call, because it expects a 
numeric ID.

I changed the type of `organization_id` in the `awx/resource_project.go` file so that an explicit error is returned.

```
Error: awx_project.test: organization_id: cannot parse '' as int: strconv.ParseInt: parsing "Default": invalid syntax
```
